### PR TITLE
Develop v2

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [Window-01, ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# get-PR-latest-commit v1
-The GitHub Action to get the latest commit on pull request. This Action (written in JavaScript) wraps the "[List commits on a pull request](https://docs.github.com/en/rest/reference/pulls#list-commits-on-a-pull-request)" API, and extracts the infomation of the latest commit from the response of the API.<BR/>
+# get-PR-latest-commit v2
+The GitHub Action to get the latest commit on pull request. This Action (written in JavaScript) wraps the "[**List commits on a pull request**](https://docs.github.com/en/rest/reference/pulls#list-commits-on-a-pull-request)" API, and extracts the infomation of the latest commit from the response of the API.<BR/>
 Through this action, you can get the following information:
 * The commit message of the latest commit.
 * The commit SHA of the latest commit.
 * The path of a JSON file generated to store the context of the latest commit.
+
+## What's new? (Fix [#5](https://github.com/ActionsRML/get-PR-latest-commit/issues/5))
+On **`v1`** of this action, we did not consider that a PR could contain too much commits. So I ignored the inputs parameters "**`per_page`**" and "**`page`**". It can only return the first page that contains up to 30 items. This causes the issue that if the PR contains more than 30 commits, the action can't return the actual latest commit on the PR. The return commit is the last one on the first page. So, the **`v1`** only can work correctly if the total count of the PR commits is less than or equal to 30.
+<br />
+<br />
+On **`v2`** of this action, we fixed this defect. The action can traverse all the pages until the last commit on the last page is found.
+> **Note:** This action still follows the limitation of the "**List commits on a pull request**" API that it can only list a maximum of 250 commits for a pull request. If the number of the PR commits is more than 250, the action will not correctly return the actual latest commit. At this time, you need to use the "[**List commits**](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-commits)" API.
+##
 
 ## Inputs
 |Name         |Required |Description                                                                                                 |Default                                  |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ On **`v1`** of this action, we did not consider that a PR could contain too much
 <br />
 <br />
 On **`v2`** of this action, we fixed this defect. The action can traverse all the pages until the last commit on the last page is found.
-> **Note:** This action still follows the limitation of the "**List commits on a pull request**" API that it can only list a maximum of 250 commits for a pull request. If the number of the PR commits is more than 250, the action will not correctly return the actual latest commit. At this time, you need to use the "[**List commits**](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-commits)" API.
+> **Note:** This action still follows the limitation of the "**List commits on a pull request**" API that it can only list a maximum of 250 commits for a pull request. If the number of the PR commits is more than 250, the action will not correctly return the actual latest commit. To receive a complete commit list for pull requests with more than 250 commits, you need to use the "[**List commits**](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-commits)" API.
 ##
 
 ## Inputs

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,6 +19,7 @@ async function run() {
       // Execute the API "List commits on a pull request", see 'https://octokit.github.io/rest.js/v18#pulls-list-commits'
       var page_number = 1;
       var obj_latest_commit;
+      var total_count = 0;
       const { Octokit } = require("@octokit/rest");
       const octokit = new Octokit({ auth: token });
       while (true) {
@@ -35,6 +36,7 @@ async function run() {
           break;
         }
         else {
+          total_count += length;
           obj_latest_commit = response.data[length - 1];
         }
         
@@ -49,7 +51,8 @@ async function run() {
       //   repo: repo_name,
       //   pull_number: pr_number
       // });
-           
+      
+      console.log(`The total count of commits on this pull request is ${total_count}.`);
       console.log(`⭐➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖ The context of latest commit ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖⭐`);
       console.log(obj_latest_commit);
       console.log(`⭐➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖⭐`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,19 +17,41 @@ async function run() {
       const repo_name = splitRepository[1];     
       
       // Execute the API "List commits on a pull request", see 'https://octokit.github.io/rest.js/v18#pulls-list-commits'
+      var page_number = 1;
+      var obj_latest_commit;
       const { Octokit } = require("@octokit/rest");
       const octokit = new Octokit({ auth: token });
-      const response = await octokit.pulls.listCommits({
-        owner: repo_owner,
-        repo: repo_name,
-        pull_number: pr_number
-      });
-      
-      // Get the index of the latest comment in the array
-      const index = response.data.length - 1;
-      
+      while (true) {
+        const response = await octokit.pulls.listCommits({
+          owner: repo_owner,
+          repo: repo_name,
+          pull_number: pr_number,
+          per_page: 100,
+          page: page_number
+        });
+
+        const length = response.data.length;
+        if (length < 1) {
+          break;
+        }
+        else {
+          obj_latest_commit = response.data[length - 1];
+        }
+        
+        if (length < 100) {
+          break;
+        }
+        page_number++;
+      }
+
+      // const response = await octokit.pulls.listCommits({
+      //   owner: repo_owner,
+      //   repo: repo_name,
+      //   pull_number: pr_number
+      // });
+           
       console.log(`⭐➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖ The context of latest commit ➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖⭐`);
-      console.log(response.data[index]);
+      console.log(obj_latest_commit);
       console.log(`⭐➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖⭐`);
       
       console.log(`>`);
@@ -44,7 +66,7 @@ async function run() {
       
       // Write the json object of the latest commit into the json file
       const fs = require('fs');
-      fs.writeFile(path_json_file, JSON.stringify(response.data[index], null, 2), (err) => {
+      fs.writeFile(path_json_file, JSON.stringify(obj_latest_commit, null, 2), (err) => {
           // In case of a error throw err. 
           if (err) throw err;
       });
@@ -52,13 +74,13 @@ async function run() {
       // Set outputs for the information of the latest commit
       console.log(`Set outputs:🔧✍`);
       core.setOutput('latest_commit_context', path_json_file);
-      console.log(`latest_commit_context = `, path_json_file);
+      console.log(`latest_commit_context =`, path_json_file);
       
-      core.setOutput('latest_commit_sha', response.data[index].sha);
-      console.log(`latest_commit_sha = `, response.data[index].sha);
+      core.setOutput('latest_commit_sha', obj_latest_commit.sha);
+      console.log(`latest_commit_sha =`, obj_latest_commit.sha);
       
-      core.setOutput('latest_commit_message', response.data[index].commit.message);
-      console.log(`latest_commit_message = `, response.data[index].commit.message);
+      core.setOutput('latest_commit_message', obj_latest_commit.commit.message);
+      console.log(`latest_commit_message =`, obj_latest_commit.commit.message);
     }
     catch (error) {
       core.setFailed(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "get-PR-latest-commit",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-PR-latest-commit",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "An action to get the latest commit on a pull request, and output the information of the latest commit, include the commit context, commit message, commit SHA.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What's changed? (Fix #5)
On **`v1`** of this action, I did not consider that a PR could contain too much commits. So I ignored the inputs parameters "**`per_page`**" and "**`page`**". It can only return the first page that contains up to 30 items. This causes the issue that if the PR contains more than 30 commits, the action can't return the actual latest commit on the PR. The return commit is the last one on the first page. So, the **`v1`** only can work correctly if the total count of the PR commits is less than or equal to 30.

On **`v2`** of this action, I will fix this defect. The action can traverse all the pages until the last commit on the last page is found.
### Note:
The **`v2`** still follows the limitation of the "List commits on a pull request" API that it can only list a maximum of 250 commits for a pull request. If the number of the PR commits is more than 250, the action will not correctly return the actual latest commit. To receive a complete commit list for pull requests with more than 250 commits, you need to use the "[**List commits**](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-commits)" API.